### PR TITLE
AI Rule: aws.ec2.gpu.idle

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -41,9 +41,50 @@ cleancloud scan --provider aws --category ai   # détectez les endpoints SageMak
 ## Exemple de résultat détaillé
 
 ```
-6 problèmes détectés :
+cleancloud scan --provider aws --category all
 
-1. [AWS] Instance RDS inactive (aucune connexion depuis 21 jours)
+10 findings détectés (6 hygiène + 4 IA/ML) :
+
+1. [AWS] Instance EC2 GPU inactive (utilisation GPU <5% sur 7 jours)
+   Risque     : Critique
+   Confiance  : High
+   Ressource  : aws.ec2.instance → i-0a1b2c3d4e5f67890
+   Région     : us-east-1
+   Règle      : aws.ec2.gpu.idle
+   Raison     : Instance GPU EC2 avec faible utilisation GPU (1,2%) depuis 7 jours
+   Détails :
+     - instance_type: p4d.24xlarge
+     - name: ml-training-cluster-node-1
+     - gpu_metric_available: true
+     - utilisation_pct: 1.2
+     - estimated_monthly_cost: ~$23 374/mois
+
+2. [GCP] Instance Workbench GPU inactive (>14 jours, 31 jours sans activité)
+   Risque     : Critique
+   Confiance  : High
+   Ressource  : gcp.vertex.workbench.instance → projects/ml-platform/locations/us-central1/instances/research-nb-gpu
+   Région     : us-central1
+   Règle      : gcp.vertex.workbench.idle
+   Raison     : Instance Workbench sans activité sur le plan de contrôle depuis 31 jours, état ACTIVE
+   Détails :
+     - machine_type: a2-highgpu-4g
+     - accelerator_type: NVIDIA_TESLA_A100
+     - accelerator_count: 4
+     - estimated_monthly_cost: ~$11 732/mois
+
+3. [Azure] Instance de calcul Azure ML inactive (31 jours sans activité)
+   Risque     : Élevé
+   Confiance  : High
+   Ressource  : azure.ml.compute_instance → ws-prod/compute/ds-workstation-nc24
+   Région     : eastus
+   Règle      : azure.ml.compute_instance.idle
+   Raison     : Instance de calcul sans activité depuis 31 jours, état Running
+   Détails :
+     - vm_size: Standard_NC24s_v3
+     - is_gpu: true
+     - estimated_monthly_cost: ~$2 190/mois
+
+4. [AWS] Instance RDS inactive (aucune connexion depuis 21 jours)
    Risque     : Élevé
    Confiance  : High
    Ressource  : aws.rds.instance → db-prod-analytics
@@ -55,19 +96,18 @@ cleancloud scan --provider aws --category ai   # détectez les endpoints SageMak
      - engine: postgres 15.4
      - estimated_monthly_cost: ~$380/mois
 
-2. [AWS] Volume EBS non attaché
-   Risque     : Faible
+5. [AWS] Endpoint SageMaker inactif (aucune invocation depuis 21 jours)
+   Risque     : Élevé
    Confiance  : High
-   Ressource  : aws.ebs.volume → vol-0a1b2c3d4e5f67890
+   Ressource  : aws.sagemaker.endpoint → fraud-detection-v2
    Région     : us-east-1
-   Règle      : aws.ebs.volume.unattached
-   Raison     : Volume non attaché depuis 47 jours
+   Règle      : aws.sagemaker.endpoint.idle
+   Raison     : Endpoint SageMaker sans invocation depuis 21 jours
    Détails :
-     - size_gb: 500
-     - state: available
-     - tags: {"Project": "legacy-api", "Owner": "platform"}
+     - instance_type: ml.g5.2xlarge
+     - estimated_monthly_cost: ~$1 008/mois
 
-3. [AWS] NAT Gateway inactive
+6. [AWS] NAT Gateway inactive
    Risque     : Moyen
    Confiance  : Medium
    Ressource  : aws.ec2.nat_gateway → nat-0abcdef1234567890
@@ -79,7 +119,7 @@ cleancloud scan --provider aws --category ai   # détectez les endpoints SageMak
      - total_bytes_out: 0
      - estimated_monthly_cost: ~$32/mois
 
-4. [AWS] Load Balancer inactif (aucune cible saine)
+7. [AWS] Load Balancer inactif (aucune cible saine)
    Risque     : Moyen
    Confiance  : High
    Ressource  : aws.elbv2.load_balancer → alb-staging-api
@@ -90,7 +130,18 @@ cleancloud scan --provider aws --category ai   # détectez les endpoints SageMak
      - type: application
      - estimated_monthly_cost: ~$18/mois
 
-5. [AWS] Elastic IP non attachée
+8. [AWS] Volume EBS non attaché
+   Risque     : Faible
+   Confiance  : High
+   Ressource  : aws.ebs.volume → vol-0a1b2c3d4e5f67890
+   Région     : us-east-1
+   Règle      : aws.ebs.volume.unattached
+   Raison     : Volume non attaché depuis 47 jours
+   Détails :
+     - size_gb: 500
+     - state: available
+
+9. [AWS] Elastic IP non attachée
    Risque     : Faible
    Confiance  : High
    Ressource  : aws.ec2.elastic_ip → eipalloc-0a1b2c3d4e5f6
@@ -98,23 +149,23 @@ cleancloud scan --provider aws --category ai   # détectez les endpoints SageMak
    Règle      : aws.ec2.elastic_ip.unattached
    Raison     : Elastic IP non associée à aucune instance ou ENI (ancienneté : 92 jours)
 
-6. [AWS] Ancien snapshot EBS (438 jours)
-   Risque     : Faible
-   Confiance  : High
-   Ressource  : aws.ebs.snapshot → snap-0a1b2c3d4e5f67890
-   Région     : us-west-2
-   Règle      : aws.ebs.snapshot.old
-   Raison     : Snapshot âgé de 438 jours sans activité récente
-   Détails :
-     - size_gb: 200
-     - estimated_monthly_cost: ~$10/mois
+10. [AWS] Ancien snapshot EBS (438 jours)
+    Risque     : Faible
+    Confiance  : High
+    Ressource  : aws.ebs.snapshot → snap-0a1b2c3d4e5f67890
+    Région     : us-west-2
+    Règle      : aws.ebs.snapshot.old
+    Raison     : Snapshot âgé de 438 jours sans activité récente
+    Détails :
+      - size_gb: 200
+      - estimated_monthly_cost: ~$10/mois
 
 --- Résumé du scan ---
-Total findings : 6
-Par risque :     faible: 3  moyen: 2  élevé: 1
-Par confiance :  high: 5  medium: 1
-Gaspillage minimum estimé : ~$480/mois
-(5 findings sur 6 chiffrés)
+Total findings : 10
+Par risque :     critique: 2  élevé: 3  moyen: 2  faible: 3
+Par confiance :  high: 9  medium: 1
+Gaspillage minimum estimé : ~$38 744/mois
+(9 findings sur 10 chiffrés)
 Régions scannées : us-east-1, us-west-2, eu-west-1 (auto-détectées)
 ```
 
@@ -145,7 +196,7 @@ Pas encore de compte cloud ? `cleancloud demo` affiche un exemple de sortie sans
 - **Détection du gaspillage IA/ML sur les 3 clouds :** endpoints SageMaker et notebooks, clusters AML Compute et instances ML, endpoints Vertex AI et instances Workbench — facturés 500–23 000 $/mois par ressource en silence. Ressources GPU flaggées risque HIGH. Les outils natifs montrent la facture — CleanCloud indique quoi supprimer. Opt-in via `--category ai`
 - **Gouvernance policy-as-code :** `cleancloud.yaml` pour la configuration par règle, les exceptions avec dates d'expiration, les seuils de coût et de confiance, les exclusions par tag — versionné aux côtés de votre infrastructure. Chaque exception est une approbation auditée dans git.
 - **Application de politique (opt-in) :** `--fail-on-confidence HIGH` ou `--fail-on-cost 500` — appliquer des seuils de gaspillage en CI/CD sur un planning, géré par les équipes platform ou FinOps
-- **36 règles de détection sélectives et haut signal :** volumes orphelins, bases de données inactives, instances arrêtées, registres inutilisés, et plus — conçues pour éviter les faux positifs en environnements IaC, chacune avec une estimation de coût déterministe
+- **37 règles de détection sélectives et haut signal :** volumes orphelins, bases de données inactives, instances arrêtées, registres inutilisés, et plus — conçues pour éviter les faux positifs en environnements IaC, chacune avec une estimation de coût déterministe
 - **Scan multi-comptes (AWS) :** scannez des AWS Organizations entières en une exécution — fichier de config, IDs inline, ou auto-découverte via `--org`
 - **Scan multi-abonnements (Azure) :** scannez tous les abonnements Azure en parallèle — auto-découverte via Management Group, détail des coûts par abonnement inclus
 - **Scan multi-projets (GCP) :** scannez tous les projets GCP accessibles en parallèle — auto-découverte via Application Default Credentials, détail des coûts par projet inclus

--- a/README.md
+++ b/README.md
@@ -41,9 +41,50 @@ cleancloud scan --provider aws --category ai   # detect idle SageMaker endpoints
 ## What It Looks Like
 
 ```
-Found 6 hygiene issues:
+cleancloud scan --provider aws --category all
 
-1. [AWS] Idle RDS Instance (No Connections for 21 Days)
+Found 10 findings (6 hygiene + 4 AI/ML):
+
+1. [AWS] Idle GPU EC2 Instance (GPU utilisation <5% over 7 days)
+   Risk       : Critical
+   Confidence : High
+   Resource   : aws.ec2.instance → i-0a1b2c3d4e5f67890
+   Region     : us-east-1
+   Rule       : aws.ec2.gpu.idle
+   Reason     : GPU EC2 instance has low GPU utilisation (1.2%) for 7 days
+   Details:
+     - instance_type: p4d.24xlarge
+     - name: ml-training-cluster-node-1
+     - gpu_metric_available: true
+     - utilisation_pct: 1.2
+     - estimated_monthly_cost: ~$23,374/month
+
+2. [GCP] Idle GPU-Backed Workbench Instance (>14 Days Idle, 31 Days Since Activity)
+   Risk       : Critical
+   Confidence : High
+   Resource   : gcp.vertex.workbench.instance → projects/ml-platform/locations/us-central1/instances/research-nb-gpu
+   Region     : us-central1
+   Rule       : gcp.vertex.workbench.idle
+   Reason     : Workbench instance has had no control-plane activity for 31 days while ACTIVE
+   Details:
+     - machine_type: a2-highgpu-4g
+     - accelerator_type: NVIDIA_TESLA_A100
+     - accelerator_count: 4
+     - estimated_monthly_cost: ~$11,732/month
+
+3. [Azure] Idle Azure ML Compute Instance (31 Days Since Last Activity)
+   Risk       : High
+   Confidence : High
+   Resource   : azure.ml.compute_instance → ws-prod/compute/ds-workstation-nc24
+   Region     : eastus
+   Rule       : azure.ml.compute_instance.idle
+   Reason     : Compute instance has had no control-plane activity for 31 days while Running
+   Details:
+     - vm_size: Standard_NC24s_v3
+     - is_gpu: true
+     - estimated_monthly_cost: ~$2,190/month
+
+4. [AWS] Idle RDS Instance (No Connections for 21 Days)
    Risk       : High
    Confidence : High
    Resource   : aws.rds.instance → db-prod-analytics
@@ -55,19 +96,18 @@ Found 6 hygiene issues:
      - engine: postgres 15.4
      - estimated_monthly_cost: ~$380/month
 
-2. [AWS] Unattached EBS Volume
-   Risk       : Low
+5. [AWS] Idle SageMaker Endpoint (No Invocations for 21 Days)
+   Risk       : High
    Confidence : High
-   Resource   : aws.ebs.volume → vol-0a1b2c3d4e5f67890
+   Resource   : aws.sagemaker.endpoint → fraud-detection-v2
    Region     : us-east-1
-   Rule       : aws.ebs.volume.unattached
-   Reason     : Volume has been unattached for 47 days
+   Rule       : aws.sagemaker.endpoint.idle
+   Reason     : SageMaker endpoint has zero invocations for 21 days
    Details:
-     - size_gb: 500
-     - state: available
-     - tags: {"Project": "legacy-api", "Owner": "platform"}
+     - instance_type: ml.g5.2xlarge
+     - estimated_monthly_cost: ~$1,008/month
 
-3. [AWS] Idle NAT Gateway
+6. [AWS] Idle NAT Gateway
    Risk       : Medium
    Confidence : Medium
    Resource   : aws.ec2.nat_gateway → nat-0abcdef1234567890
@@ -79,7 +119,7 @@ Found 6 hygiene issues:
      - total_bytes_out: 0
      - estimated_monthly_cost: ~$32/month
 
-4. [AWS] Idle Load Balancer (No Healthy Targets)
+7. [AWS] Idle Load Balancer (No Healthy Targets)
    Risk       : Medium
    Confidence : High
    Resource   : aws.elbv2.load_balancer → alb-staging-api
@@ -90,7 +130,18 @@ Found 6 hygiene issues:
      - type: application
      - estimated_monthly_cost: ~$18/month
 
-5. [AWS] Unattached Elastic IP
+8. [AWS] Unattached EBS Volume
+   Risk       : Low
+   Confidence : High
+   Resource   : aws.ebs.volume → vol-0a1b2c3d4e5f67890
+   Region     : us-east-1
+   Rule       : aws.ebs.volume.unattached
+   Reason     : Volume has been unattached for 47 days
+   Details:
+     - size_gb: 500
+     - state: available
+
+9. [AWS] Unattached Elastic IP
    Risk       : Low
    Confidence : High
    Resource   : aws.ec2.elastic_ip → eipalloc-0a1b2c3d4e5f6
@@ -98,23 +149,23 @@ Found 6 hygiene issues:
    Rule       : aws.ec2.elastic_ip.unattached
    Reason     : Elastic IP not associated with any instance or ENI (age: 92 days)
 
-6. [AWS] Old EBS Snapshot (438 Days)
-   Risk       : Low
-   Confidence : High
-   Resource   : aws.ebs.snapshot → snap-0a1b2c3d4e5f67890
-   Region     : us-west-2
-   Rule       : aws.ebs.snapshot.old
-   Reason     : Snapshot is 438 days old with no recent activity
-   Details:
-     - size_gb: 200
-     - estimated_monthly_cost: ~$10/month
+10. [AWS] Old EBS Snapshot (438 Days)
+    Risk       : Low
+    Confidence : High
+    Resource   : aws.ebs.snapshot → snap-0a1b2c3d4e5f67890
+    Region     : us-west-2
+    Rule       : aws.ebs.snapshot.old
+    Reason     : Snapshot is 438 days old with no recent activity
+    Details:
+      - size_gb: 200
+      - estimated_monthly_cost: ~$10/month
 
 --- Scan Summary ---
-Total findings: 6
-By risk:        low: 3  medium: 2  high: 1
-By confidence:  high: 5  medium: 1
-Minimum estimated waste: ~$480/month
-(5 of 6 findings costed)
+Total findings: 10
+By risk:        critical: 2  high: 3  medium: 2  low: 3
+By confidence:  high: 9  medium: 1
+Minimum estimated waste: ~$38,744/month
+(9 of 10 findings costed)
 Regions scanned: us-east-1, us-west-2, eu-west-1 (auto-detected)
 ```
 
@@ -145,7 +196,7 @@ No cloud account yet? `cleancloud demo` shows sample output without any credenti
 - **AI/ML waste detection across all 3 clouds:** idle SageMaker endpoints and notebooks, AML compute clusters and instances, Vertex AI endpoints and Workbench instances — silently billing $500–$23K/month per resource. GPU-backed resources flagged HIGH risk. Native cost tools don't surface these — CleanCloud does. Opt-in via `--category ai`
 - **Policy-as-code governance:** `cleancloud.yaml` for per-rule config, exceptions with expiry dates, cost and confidence thresholds, tag-based exclusions — version-controlled alongside your infrastructure. Every exception is a git-reviewable approval.
 - **Governance enforcement (opt-in):** `--fail-on-confidence HIGH` or `--fail-on-cost 500` — enforce waste thresholds in CI/CD on a schedule, owned by platform or FinOps teams
-- **36 curated, high-signal detection rules:** orphaned volumes, idle databases, stopped instances, unused registries, and more — designed to avoid false positives in IaC environments, each with a deterministic cost estimate
+- **37 curated, high-signal detection rules:** orphaned volumes, idle databases, stopped instances, unused registries, and more — designed to avoid false positives in IaC environments, each with a deterministic cost estimate
 - **Multi-account scanning (AWS):** scan entire AWS Organizations in one run — config file, inline IDs, or auto-discovery via `--org`
 - **Multi-subscription scanning (Azure):** scan all Azure subscriptions in parallel — auto-discovery via Management Group, per-subscription cost breakdown included
 - **Multi-project scanning (GCP):** scan all accessible GCP projects in parallel — auto-discovery via Application Default Credentials, per-project cost breakdown included

--- a/cleancloud.yaml
+++ b/cleancloud.yaml
@@ -82,6 +82,12 @@ rules:
     # It does NOT affect fail_on_confidence thresholds (which use signal strength, not risk).
     override_risk_level: HIGH
 
+  # aws.ec2.gpu.idle:
+  #   params:
+  #     idle_days: 14           # default: 7   (days of low utilisation before flagging)
+  #     gpu_threshold: 10.0     # default: 5.0 (max GPU utilisation %, HIGH confidence path)
+  #     cpu_threshold: 20.0     # default: 10.0 (max CPU utilisation %, MEDIUM confidence fallback)
+
 # ── Categories ───────────────────────────────────────────────────────────────
 # Override the default category without using the --category CLI flag.
 # Equivalent to: cleancloud scan --provider aws --category all

--- a/cleancloud/doctor/aws.py
+++ b/cleancloud/doctor/aws.py
@@ -706,6 +706,27 @@ def run_aws_ai_doctor(profile: Optional[str], region: Optional[str] = None) -> N
         permissions_failed.append(("cloudwatch:GetMetricStatistics", str(e)))
         warn(f"cloudwatch:GetMetricStatistics - {e}")
 
+    # --- ec2:DescribeInstances (aws.ec2.gpu.idle) ---
+    try:
+        ec2 = session.client("ec2", region_name=region)
+        ec2.describe_instances(
+            MaxResults=5, Filters=[{"Name": "instance-state-name", "Values": ["running"]}]
+        )
+        permissions_tested.append("ec2:DescribeInstances")
+        success("ec2:DescribeInstances")
+    except Exception as e:
+        permissions_failed.append(("ec2:DescribeInstances", str(e)))
+        warn(f"ec2:DescribeInstances - {e}")
+
+    # --- cloudwatch:ListMetrics (aws.ec2.gpu.idle — GPU metric probe) ---
+    try:
+        cloudwatch.list_metrics(Namespace="CWAgent", MetricName="nvidia_smi_utilization_gpu")
+        permissions_tested.append("cloudwatch:ListMetrics")
+        success("cloudwatch:ListMetrics")
+    except Exception as e:
+        permissions_failed.append(("cloudwatch:ListMetrics", str(e)))
+        warn(f"cloudwatch:ListMetrics - {e}")
+
     info("")
     info("=" * 70)
     total = len(permissions_tested) + len(permissions_failed)

--- a/cleancloud/providers/aws/rules/ec2_gpu_idle.py
+++ b/cleancloud/providers/aws/rules/ec2_gpu_idle.py
@@ -1,0 +1,440 @@
+from datetime import datetime, timedelta, timezone
+from typing import List, Optional
+
+import boto3
+from botocore.exceptions import ClientError
+
+from cleancloud.core.confidence import ConfidenceLevel
+from cleancloud.core.evidence import Evidence
+from cleancloud.core.finding import Finding
+from cleancloud.core.risk import RiskLevel
+
+RULE_METADATA = {
+    "id": "aws.ec2.gpu.idle",
+    "category": "ai",
+    "service": "ec2",
+    "cost_impact": "high",
+}
+
+# GPU/accelerator EC2 instance families (raw EC2, not SageMaker)
+_GPU_FAMILIES = (
+    "p2.",
+    "p3.",
+    "p3dn.",
+    "p4d.",
+    "p4de.",
+    "p5.",
+    "g4dn.",
+    "g4ad.",
+    "g5.",
+    "g5g.",
+    "g6.",
+    "g6e.",
+    "gr6.",
+    "trn1.",
+    "trn1n.",
+    "trn2.",
+    "inf1.",
+    "inf2.",
+    "dl1.",
+    "dl2q.",
+)
+
+# On-demand monthly cost (us-east-1, 730 h/month)
+_MONTHLY_COST = {
+    # P2 (NVIDIA K80)
+    "p2.xlarge": 657.0,
+    "p2.8xlarge": 5_256.0,
+    "p2.16xlarge": 10_512.0,
+    # P3 (NVIDIA V100)
+    "p3.2xlarge": 2_234.0,
+    "p3.8xlarge": 8_935.0,
+    "p3.16xlarge": 17_870.0,
+    "p3dn.24xlarge": 23_882.0,
+    # P4 (NVIDIA A100 40GB)
+    "p4d.24xlarge": 23_374.0,
+    # P4de (NVIDIA A100 80GB)
+    "p4de.24xlarge": 32_074.0,
+    # P5 (NVIDIA H100)
+    "p5.48xlarge": 98_318.0,
+    # G4dn (NVIDIA T4)
+    "g4dn.xlarge": 379.0,
+    "g4dn.2xlarge": 601.0,
+    "g4dn.4xlarge": 1_166.0,
+    "g4dn.8xlarge": 1_752.0,
+    "g4dn.12xlarge": 2_918.0,
+    "g4dn.16xlarge": 3_504.0,
+    "g4dn.metal": 5_837.0,
+    # G4ad (AMD Radeon Pro V520)
+    "g4ad.xlarge": 261.0,
+    "g4ad.2xlarge": 396.0,
+    "g4ad.4xlarge": 698.0,
+    "g4ad.8xlarge": 1_295.0,
+    "g4ad.16xlarge": 2_474.0,
+    # G5 (NVIDIA A10G)
+    "g5.xlarge": 604.0,
+    "g5.2xlarge": 730.0,
+    "g5.4xlarge": 1_168.0,
+    "g5.8xlarge": 1_972.0,
+    "g5.12xlarge": 2_956.0,
+    "g5.16xlarge": 3_358.0,
+    "g5.24xlarge": 4_380.0,
+    "g5.48xlarge": 8_760.0,
+    # G5g (NVIDIA T4g — ARM)
+    "g5g.xlarge": 279.0,
+    "g5g.2xlarge": 416.0,
+    "g5g.4xlarge": 700.0,
+    "g5g.8xlarge": 1_209.0,
+    "g5g.16xlarge": 2_190.0,
+    # G6 (NVIDIA L4)
+    "g6.xlarge": 604.0,
+    "g6.2xlarge": 730.0,
+    "g6.4xlarge": 1_095.0,
+    "g6.8xlarge": 1_825.0,
+    "g6.12xlarge": 2_738.0,
+    "g6.16xlarge": 3_066.0,
+    "g6.24xlarge": 4_599.0,
+    "g6.48xlarge": 9_198.0,
+    # G6e (NVIDIA L40S)
+    "g6e.xlarge": 1_460.0,
+    "g6e.2xlarge": 1_971.0,
+    "g6e.4xlarge": 3_138.0,
+    "g6e.8xlarge": 5_256.0,
+    "g6e.12xlarge": 7_884.0,
+    "g6e.16xlarge": 9_636.0,
+    "g6e.24xlarge": 13_140.0,
+    "g6e.48xlarge": 18_000.0,
+    # Gr6 (NVIDIA L4 — high memory)
+    "gr6.4xlarge": 1_095.0,
+    "gr6.8xlarge": 1_752.0,
+    # Trn1 (AWS Trainium)
+    "trn1.2xlarge": 657.0,
+    "trn1.32xlarge": 10_512.0,
+    "trn1n.32xlarge": 11_753.0,
+    # Trn2 (AWS Trainium2)
+    "trn2.48xlarge": 110_000.0,
+    # Inf1 (AWS Inferentia)
+    "inf1.xlarge": 183.0,
+    "inf1.2xlarge": 292.0,
+    "inf1.6xlarge": 875.0,
+    "inf1.24xlarge": 3_503.0,
+    # Inf2 (AWS Inferentia2)
+    "inf2.xlarge": 438.0,
+    "inf2.8xlarge": 3_504.0,
+    "inf2.24xlarge": 10_512.0,
+    "inf2.48xlarge": 21_024.0,
+    # DL1 (Habana Gaudi)
+    "dl1.24xlarge": 13_140.0,
+    # DL2q (Qualcomm)
+    "dl2q.24xlarge": 8_760.0,
+}
+_DEFAULT_MONTHLY_COST = 600.0
+
+# GPU utilisation thresholds
+_GPU_UTIL_THRESHOLD_PCT = 5.0  # below this = idle (when GPU metric available)
+_CPU_UTIL_THRESHOLD_PCT = 10.0  # below this = idle (CPU fallback)
+
+# Neuron accelerator families — use AWS Neuron SDK, not NVIDIA CUDA.
+# nvidia_smi_utilization_gpu is never published for these; CPU fallback is expected.
+_NEURON_FAMILIES = ("trn1.", "trn1n.", "trn2.", "inf1.", "inf2.", "dl1.", "dl2q.")
+
+_DAYS_IDLE = 7
+
+
+def find_idle_gpu_instances(
+    session: boto3.Session,
+    region: str,
+    idle_days: int = _DAYS_IDLE,
+    gpu_threshold: float = _GPU_UTIL_THRESHOLD_PCT,
+    cpu_threshold: float = _CPU_UTIL_THRESHOLD_PCT,
+) -> List[Finding]:
+    """
+    Find EC2 GPU instances (p2/p3/p4/p5/g4/g5/g6/trn/inf/dl) with low utilisation.
+
+    GPU instances (raw EC2, outside SageMaker) incur continuous charges while running
+    regardless of whether GPUs are being utilised. A p4d.24xlarge costs ~$23K/month
+    whether or not a training job is running. Teams frequently leave GPU instances
+    running after a job completes, between experiments, or when a project stalls.
+
+    Detection logic:
+    - Instance state is running
+    - Instance type is a known GPU/accelerator family
+    - Instance is older than idle_days (avoids flagging newly launched instances)
+    - GPU utilisation < gpu_threshold % over idle_days (HIGH confidence, when NVIDIA
+      CloudWatch agent publishes nvidia_smi_utilization_gpu under CWAgent namespace)
+    - OR CPU utilisation < cpu_threshold % over idle_days (MEDIUM confidence fallback,
+      used when GPU metrics are not available — CPU alone is a weaker signal)
+
+    GPU metric detection:
+    The NVIDIA CloudWatch agent publishes nvidia_smi_utilization_gpu under the CWAgent
+    namespace with an InstanceId dimension. Availability is probed via ListMetrics per
+    instance — not assumed. Instances without the agent fall back to CPU utilisation.
+
+    Multi-GPU handling:
+    For multi-GPU instances (e.g., p4d.24xlarge has 8 A100s), the MAX statistic is
+    used across all GPU index dimensions. A single active GPU on an 8-GPU instance
+    would be averaged away using AVG, producing a misleadingly low reading.
+
+    Confidence:
+    - HIGH: GPU metric available AND max GPU utilisation < gpu_threshold over idle_days
+    - MEDIUM: GPU metric unavailable, CPU utilisation < cpu_threshold over idle_days
+
+    IAM permissions:
+    - ec2:DescribeInstances
+    - cloudwatch:GetMetricStatistics
+    - cloudwatch:ListMetrics
+    """
+    idle_days = max(idle_days, 1)
+
+    ec2 = session.client("ec2", region_name=region)
+    cloudwatch = session.client("cloudwatch", region_name=region)
+    now = datetime.now(timezone.utc)
+    findings: List[Finding] = []
+
+    try:
+        paginator = ec2.get_paginator("describe_instances")
+        pages = paginator.paginate(Filters=[{"Name": "instance-state-name", "Values": ["running"]}])
+
+        for page in pages:
+            for reservation in page.get("Reservations", []):
+                for inst in reservation.get("Instances", []):
+                    # Only running instances incur compute charges
+                    if inst.get("State", {}).get("Name") != "running":
+                        continue
+
+                    instance_type = inst.get("InstanceType", "")
+                    if not _is_gpu_instance(instance_type):
+                        continue
+
+                    instance_id = inst["InstanceId"]
+                    tags = {t["Key"]: t["Value"] for t in inst.get("Tags", [])}
+                    launch_time = inst.get("LaunchTime")
+
+                    age_days: Optional[int] = None
+                    if launch_time:
+                        if launch_time.tzinfo is None:
+                            launch_time = launch_time.replace(tzinfo=timezone.utc)
+                        age_days = (now - launch_time).days
+
+                    # Skip instances younger than idle_days — too new to classify
+                    if age_days is not None and age_days < idle_days:
+                        continue
+
+                    # Probe for GPU metrics — single ListMetrics call reused for stats
+                    gpu_metrics = _list_gpu_metrics(cloudwatch, instance_id)
+
+                    if gpu_metrics:
+                        max_gpu_util = _get_max_gpu_utilisation(
+                            cloudwatch, gpu_metrics, idle_days, now
+                        )
+                        if max_gpu_util is None or max_gpu_util >= gpu_threshold:
+                            continue
+                        confidence = ConfidenceLevel.HIGH
+                        idle_signal = "gpu_utilisation"
+                        util_value = max_gpu_util
+                        util_label = f"Max GPU utilisation: {max_gpu_util:.1f}% (threshold: {gpu_threshold}%)"
+                    else:
+                        avg_cpu = _get_avg_cpu_utilisation(cloudwatch, instance_id, idle_days, now)
+                        if avg_cpu is None or avg_cpu >= cpu_threshold:
+                            continue
+                        confidence = ConfidenceLevel.MEDIUM
+                        idle_signal = "cpu_utilisation_fallback"
+                        util_value = avg_cpu
+                        util_label = f"Avg CPU utilisation: {avg_cpu:.1f}% (threshold: {cpu_threshold}%, GPU metric unavailable)"
+
+                    monthly_cost = _MONTHLY_COST.get(instance_type, _DEFAULT_MONTHLY_COST)
+                    idle_ratio = round(age_days / idle_days, 2) if (age_days and idle_days) else 0.0
+
+                    if idle_ratio >= 2.0:
+                        risk = RiskLevel.CRITICAL
+                    else:
+                        risk = RiskLevel.HIGH
+
+                    name_tag = tags.get("Name", instance_id)
+
+                    signals = [
+                        "Instance state: running",
+                        f"Instance type: {instance_type} (GPU/accelerator family)",
+                        util_label,
+                    ]
+                    if age_days is not None:
+                        signals.append(f"Instance age: {age_days} days")
+                    if not gpu_metrics:
+                        if _is_neuron_instance(instance_type):
+                            signals.append(
+                                "Neuron instance (Trainium/Inferentia) — no NVIDIA GPU metric "
+                                "available by design; CPU utilisation used as fallback signal; "
+                                "confidence capped at MEDIUM"
+                            )
+                        else:
+                            signals.append(
+                                "NVIDIA CloudWatch agent not detected — GPU metric unavailable; "
+                                "CPU utilisation used as fallback signal; confidence capped at MEDIUM"
+                            )
+
+                    not_checked = [
+                        "GPU processes not visible without nvidia-smi or DCGM agent",
+                        "Scheduled batch jobs that run outside the observation window",
+                        "Planned future use",
+                        "Spot instance hibernation state",
+                    ]
+
+                    evidence = Evidence(
+                        signals_used=signals,
+                        signals_not_checked=not_checked,
+                        time_window=f"{idle_days} days",
+                    )
+
+                    metric_label = "GPU" if gpu_metrics else "CPU (fallback)"
+                    findings.append(
+                        Finding(
+                            provider="aws",
+                            rule_id="aws.ec2.gpu.idle",
+                            resource_type="aws.ec2.instance",
+                            resource_id=instance_id,
+                            region=region,
+                            estimated_monthly_cost_usd=monthly_cost,
+                            title=(
+                                f"Idle GPU EC2 Instance ({metric_label} utilisation "
+                                f"<{gpu_threshold if gpu_metrics else cpu_threshold}% "
+                                f"over {idle_days} days)"
+                            ),
+                            summary=(
+                                f"EC2 instance '{name_tag}' ({instance_type}) has had "
+                                f"{'GPU' if gpu_metrics else 'CPU'} utilisation below "
+                                f"{gpu_threshold if gpu_metrics else cpu_threshold}% "
+                                f"for {idle_days} days while running, incurring "
+                                f"continuous charges (~${monthly_cost:,.0f}/month)."
+                            ),
+                            reason=(
+                                f"GPU EC2 instance has low "
+                                f"{'GPU' if gpu_metrics else 'CPU'} utilisation "
+                                f"({util_value:.1f}%) for {idle_days} days"
+                            ),
+                            risk=risk,
+                            confidence=confidence,
+                            detected_at=now,
+                            evidence=evidence,
+                            details={
+                                "instance_id": instance_id,
+                                "instance_type": instance_type,
+                                "name": name_tag,
+                                "age_days": age_days if age_days is not None else "unknown",
+                                "idle_days_threshold": idle_days,
+                                "idle_ratio": idle_ratio,
+                                "idle_signal": idle_signal,
+                                "utilisation_pct": round(util_value, 2),
+                                "gpu_metric_available": bool(gpu_metrics),
+                                "gpu_threshold_pct": gpu_threshold,
+                                "cpu_threshold_pct": cpu_threshold,
+                                "estimated_monthly_cost": f"~${monthly_cost:,.0f}/month",
+                                "cost_basis": "us-east-1 on-demand",
+                                "tags": tags,
+                            },
+                        )
+                    )
+
+    except ClientError as e:
+        code = e.response["Error"]["Code"]
+        if code in ("UnauthorizedOperation", "AccessDenied"):
+            raise PermissionError(
+                "Missing required IAM permissions: "
+                "ec2:DescribeInstances, cloudwatch:GetMetricStatistics, cloudwatch:ListMetrics"
+            ) from e
+        raise
+
+    return findings
+
+
+find_idle_gpu_instances.RULE_ID = "aws.ec2.gpu.idle"
+
+
+def _is_gpu_instance(instance_type: str) -> bool:
+    return any(instance_type.startswith(fam) for fam in _GPU_FAMILIES)
+
+
+def _is_neuron_instance(instance_type: str) -> bool:
+    return any(instance_type.startswith(fam) for fam in _NEURON_FAMILIES)
+
+
+def _list_gpu_metrics(cloudwatch, instance_id: str) -> list:
+    """
+    Probe CloudWatch ListMetrics for nvidia_smi_utilization_gpu under CWAgent namespace.
+
+    Returns the Metrics list (one entry per GPU index) so the caller can reuse it
+    for GetMetricStatistics without a second ListMetrics call. Returns [] on any error.
+    """
+    try:
+        resp = cloudwatch.list_metrics(
+            Namespace="CWAgent",
+            MetricName="nvidia_smi_utilization_gpu",
+            Dimensions=[{"Name": "InstanceId", "Value": instance_id}],
+        )
+        return resp.get("Metrics", [])
+    except ClientError:
+        return []
+
+
+def _get_max_gpu_utilisation(
+    cloudwatch, gpu_metrics: list, days: int, now: datetime
+) -> Optional[float]:
+    """
+    Return the maximum GPU utilisation across all GPU indices over the window.
+
+    Takes the gpu_metrics list already fetched by _list_gpu_metrics — no second
+    ListMetrics call. Uses MAX statistic so a single active GPU on a multi-GPU
+    instance (e.g., p4d.24xlarge with 8 A100s) is not averaged away.
+
+    Returns None on error — caller treats None as "not idle" (safe default).
+    """
+    start = now - timedelta(days=days)
+    max_util: Optional[float] = None
+
+    for metric in gpu_metrics:
+        dimensions = metric.get("Dimensions", [])
+        try:
+            stats = cloudwatch.get_metric_statistics(
+                Namespace="CWAgent",
+                MetricName="nvidia_smi_utilization_gpu",
+                Dimensions=dimensions,
+                StartTime=start,
+                EndTime=now,
+                Period=3600,
+                Statistics=["Maximum"],
+            )
+            datapoints = stats.get("Datapoints", [])
+            if not datapoints:
+                continue
+            gpu_max = max(dp["Maximum"] for dp in datapoints)
+            if max_util is None or gpu_max > max_util:
+                max_util = gpu_max
+        except ClientError:
+            continue
+
+    return max_util
+
+
+def _get_avg_cpu_utilisation(
+    cloudwatch, instance_id: str, days: int, now: datetime
+) -> Optional[float]:
+    """
+    Return the average CPU utilisation over the window using AWS/EC2 CPUUtilization.
+    Returns None on error — caller treats None as "not idle" (safe default).
+    """
+    start = now - timedelta(days=days)
+    try:
+        resp = cloudwatch.get_metric_statistics(
+            Namespace="AWS/EC2",
+            MetricName="CPUUtilization",
+            Dimensions=[{"Name": "InstanceId", "Value": instance_id}],
+            StartTime=start,
+            EndTime=now,
+            Period=86400,  # 1-day granularity
+            Statistics=["Average"],
+        )
+        datapoints = resp.get("Datapoints", [])
+        if not datapoints:
+            return None
+        return sum(dp["Average"] for dp in datapoints) / len(datapoints)
+    except ClientError:
+        return None

--- a/cleancloud/providers/aws/scan.py
+++ b/cleancloud/providers/aws/scan.py
@@ -13,6 +13,7 @@ from cleancloud.providers.aws.rules.cloudwatch_inactive import (
 )
 from cleancloud.providers.aws.rules.ebs_snapshot_old import find_old_ebs_snapshots
 from cleancloud.providers.aws.rules.ebs_unattached import find_unattached_ebs_volumes
+from cleancloud.providers.aws.rules.ec2_gpu_idle import find_idle_gpu_instances
 from cleancloud.providers.aws.rules.ec2_sg_unused import find_unused_security_groups
 from cleancloud.providers.aws.rules.ec2_stopped import find_stopped_ec2_instances
 from cleancloud.providers.aws.rules.elastic_ip_unattached import (
@@ -54,6 +55,7 @@ AWS_RULE_MAP: Dict[str, Callable] = {
 AWS_RULE_MAP_AI: Dict[str, Callable] = {
     "aws.sagemaker.endpoint.idle": find_idle_sagemaker_endpoints,
     "aws.sagemaker.notebook.idle": find_idle_sagemaker_notebooks,
+    "aws.ec2.gpu.idle": find_idle_gpu_instances,
 }
 
 AWS_RULES: List[Callable] = list(AWS_RULE_MAP.values())

--- a/deploy/cloudformation/cleancloud-role.yaml
+++ b/deploy/cloudformation/cleancloud-role.yaml
@@ -126,10 +126,16 @@ Resources:
               - sagemaker:ListNotebookInstances
               - sagemaker:DescribeNotebookInstance
             Resource: "*"
-          - Sid: CloudWatchMetrics
+          - Sid: EC2GPUReadOnly
+            Effect: Allow
+            Action:
+              - ec2:DescribeInstances
+            Resource: "*"
+          - Sid: CloudWatchGPUMetrics
             Effect: Allow
             Action:
               - cloudwatch:GetMetricStatistics
+              - cloudwatch:ListMetrics
             Resource: "*"
 
 Outputs:

--- a/deploy/terraform/aws/main.tf
+++ b/deploy/terraform/aws/main.tf
@@ -55,10 +55,19 @@ resource "aws_iam_role_policy" "cleancloud_ai" {
         Resource = "*"
       },
       {
-        Sid    = "CloudWatchMetrics"
+        Sid    = "EC2GPUReadOnly"
+        Effect = "Allow"
+        Action = [
+          "ec2:DescribeInstances",
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "CloudWatchGPUMetrics"
         Effect = "Allow"
         Action = [
           "cloudwatch:GetMetricStatistics",
+          "cloudwatch:ListMetrics",
         ]
         Resource = "*"
       },

--- a/docs/aws.md
+++ b/docs/aws.md
@@ -307,7 +307,7 @@ For the complete production workflow with enforcement flags, scheduling, and art
 > |------|----------|---------------|
 > | `base-readonly.json` | `sts:GetCallerIdentity`, `cloudwatch:GetMetricStatistics` | **Always — every scan, every category** |
 > | `hygiene-readonly.json` | EC2, RDS, ELB, S3, logs | `--category hygiene` (default) |
-> | `ai-readonly.json` | SageMaker | `--category ai` |
+> | `ai-readonly.json` | SageMaker, EC2 GPU instances, CloudWatch GPU metrics | `--category ai` |
 >
 > `base-readonly.json` must be attached alongside any category file. It provides `cloudwatch:GetMetricStatistics` (used by the NAT gateway, RDS, and ELB idle rules) and `sts:GetCallerIdentity` (used at startup to verify credentials). A role with only `hygiene-readonly.json` attached will have CloudWatch metric calls fail silently on those rules.
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -182,7 +182,7 @@ The simplest way to add CleanCloud to GitHub Actions — one step, no pip instal
 | Input | Description | AWS | Azure | GCP |
 |---|---|:---:|:---:|:---:|
 | `provider` | `aws`, `azure`, or `gcp` (required) | ✓ | ✓ | ✓ |
-| `category` | `hygiene` (default), `ai` (SageMaker on AWS, AML Compute on Azure), or `all` | ✓ | ✓ | — |
+| `category` | `hygiene` (default), `ai` (SageMaker + EC2 GPU on AWS, AML Compute on Azure, Vertex AI on GCP), or `all` | ✓ | ✓ | — |
 | `region` | Single region filter (AWS) or location filter (Azure — filters results; all subscriptions always scanned) | ✓ | ✓ | — |
 | `all-regions` | Scan all active AWS regions (AWS-only; Azure scans all subscriptions by default) | ✓ | — | — |
 | `org` | Auto-discover all AWS Organization accounts | ✓ | — | — |
@@ -550,9 +550,9 @@ jobs:
           retention-days: 30
 ```
 
-### AWS AI/ML Scan (SageMaker)
+### AWS AI/ML Scan (SageMaker + EC2 GPU)
 
-Run SageMaker idle resource detection (endpoints + notebook instances) separately — requires the `security/aws/ai-readonly.json` policy attached to your IAM role.
+Run AI/ML idle resource detection (SageMaker endpoints + notebook instances, EC2 GPU/accelerator instances) separately — requires the `security/aws/ai-readonly.json` policy attached to your IAM role.
 
 ```yaml
 name: CleanCloud AI/ML Scan

--- a/docs/infosec-readiness.md
+++ b/docs/infosec-readiness.md
@@ -274,7 +274,7 @@ AWS permissions are split across three composable policy files under [`security/
 |------|---------|--------------|
 | [`base-readonly.json`](../security/aws/base-readonly.json) | STS identity + CloudWatch metrics | All scans |
 | [`hygiene-readonly.json`](../security/aws/hygiene-readonly.json) | EC2, RDS, ELB, S3, logs | `--category hygiene` (default) |
-| [`ai-readonly.json`](../security/aws/ai-readonly.json) | SageMaker | `--category ai` |
+| [`ai-readonly.json`](../security/aws/ai-readonly.json) | SageMaker, EC2 GPU instances | `--category ai` |
 
 **Verification:**
 
@@ -587,7 +587,7 @@ cd cleancloud
 # AWS
 # - security/aws/base-readonly.json              (AWS base policy — all scans)
 # - security/aws/hygiene-readonly.json           (AWS hygiene rules policy)
-# - security/aws/ai-readonly.json                (AWS AI/ML rules policy — SageMaker)
+# - security/aws/ai-readonly.json                (AWS AI/ML rules policy — SageMaker, EC2 GPU)
 # Azure
 # - security/azure/hygiene-readonly-role.json    (Azure hygiene rules custom role)
 # - security/azure/ai-readonly-role.json         (Azure AI/ML rules custom role — AML Compute)

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1,6 +1,6 @@
 # CleanCloud Rules
 
-Complete reference for all 36 rules implemented by CleanCloud (30 hygiene + 6 AI/ML).
+Complete reference for all 37 rules implemented by CleanCloud (30 hygiene + 7 AI/ML).
 
 ---
 
@@ -52,6 +52,7 @@ Every finding includes a confidence level:
 | `aws.resource.untagged` | Governance | EC2/S3/CloudWatch resources with zero tags |
 | `aws.sagemaker.endpoint.idle` | AI/ML | SageMaker endpoints with zero invocations 14+ days *(opt-in: `--category ai`)* |
 | `aws.sagemaker.notebook.idle` | AI/ML | SageMaker Notebook Instances InService with no activity 14+ days *(opt-in: `--category ai`)* |
+| `aws.ec2.gpu.idle` | AI/ML | EC2 GPU/accelerator instances (p/g/trn/inf/dl families) running with <5% GPU or <10% CPU utilisation over 7 days *(opt-in: `--category ai`)* |
 
 **Azure:**
 
@@ -787,6 +788,56 @@ SageMaker Notebook Instances do not publish utilisation metrics to CloudWatch by
 - `sagemaker:DescribeNotebookInstance`
 
 > **Not run by default.** AI/ML rules are opt-in to avoid surprising users who don't use these services. Run with `cleancloud scan --provider aws --category ai` (or `--category all` to combine with hygiene rules). If the permissions above are not granted, the rule is gracefully skipped and reported in the skipped rules section — it will not fail the scan. Attach [`security/aws/ai-readonly.json`](../security/aws/ai-readonly.json) to your IAM role to enable this rule.
+
+---
+
+#### Idle EC2 GPU Instances
+
+**Rule ID:** `aws.ec2.gpu.idle`
+
+**Category:** `ai`
+
+**What it detects:** EC2 GPU and accelerator instances (p2/p3/p4/p5, g4dn/g4ad/g5/g5g/g6/g6e/gr6, trn1/trn2, inf1/inf2, dl1/dl2q families) in `running` state with low utilisation over 7+ days (default, configurable). Unlike SageMaker rules which target managed services, this rule catches raw GPU instances spun up directly for training, inference, or experimentation and left running after the job completes.
+
+Detection uses two tiers based on metric availability:
+- **GPU utilisation (HIGH confidence):** When the NVIDIA CloudWatch agent is installed, `nvidia_smi_utilization_gpu` is read from the `CWAgent` namespace. MAX statistic across all GPU indices is used — a single active GPU on a multi-GPU instance (e.g., p4d.24xlarge with 8 A100s) will not be masked by averaging.
+- **CPU utilisation fallback (MEDIUM confidence):** When the NVIDIA agent is not installed, `CPUUtilization` from `AWS/EC2` is used as a proxy signal. Neuron instances (Trainium/Inferentia) always use this path by design — they use the AWS Neuron SDK, not NVIDIA CUDA.
+
+**Confidence levels:**
+- **HIGH:** GPU metric available AND max GPU utilisation < 5% over 7 days
+- **MEDIUM:** GPU metric unavailable; avg CPU utilisation < 10% over 7 days
+
+**Risk levels:**
+- **CRITICAL:** `idle_ratio ≥ 2.0` (e.g. running for 14+ days at the 7-day threshold)
+- **HIGH:** GPU/accelerator instance with low utilisation (all other cases)
+
+**Cost estimates (us-east-1 on-demand):**
+
+| Instance | Est. monthly cost |
+|---|---|
+| g4dn.xlarge (T4) | $379 |
+| g5.xlarge (A10G) | $604 |
+| p3.2xlarge (V100) | $2,234 |
+| p4d.24xlarge (8× A100 40GB) | $23,374 |
+| p4de.24xlarge (8× A100 80GB) | $32,074 |
+| g6e.48xlarge (8× L40S) | $18,000 |
+| p5.48xlarge (8× H100) | $98,318 |
+| trn2.48xlarge (Trainium2) | $110,000 |
+
+**Configurable parameters:**
+
+| Parameter | Default | Description |
+|---|---|---|
+| `idle_days` | `7` | Days of low utilisation before flagging |
+| `gpu_threshold` | `5.0` | Max GPU utilisation % (HIGH confidence path) |
+| `cpu_threshold` | `10.0` | Max CPU utilisation % (MEDIUM confidence fallback) |
+
+**Required permissions:**
+- `ec2:DescribeInstances`
+- `cloudwatch:GetMetricStatistics`
+- `cloudwatch:ListMetrics`
+
+> **Not run by default.** Run with `cleancloud scan --provider aws --category ai`. Attach [`security/aws/ai-readonly.json`](../security/aws/ai-readonly.json) to your IAM role to enable this rule. The NVIDIA CloudWatch agent is not required — instances without it fall back to CPU utilisation at MEDIUM confidence.
 
 ---
 

--- a/security/aws/ai-readonly.json
+++ b/security/aws/ai-readonly.json
@@ -12,6 +12,23 @@
         "sagemaker:DescribeNotebookInstance"
       ],
       "Resource": "*"
+    },
+    {
+      "Sid": "EC2GPUReadOnly",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DescribeInstances"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "CloudWatchGPUMetrics",
+      "Effect": "Allow",
+      "Action": [
+        "cloudwatch:GetMetricStatistics",
+        "cloudwatch:ListMetrics"
+      ],
+      "Resource": "*"
     }
   ]
 }

--- a/tests/cleancloud/providers/aws/test_aws_ec2_gpu_idle.py
+++ b/tests/cleancloud/providers/aws/test_aws_ec2_gpu_idle.py
@@ -1,0 +1,420 @@
+"""
+Tests for aws.ec2.gpu.idle rule.
+
+Coverage:
+- Core detection: idle GPU instance flagged (HIGH confidence when GPU metric available)
+- CPU fallback: MEDIUM confidence when NVIDIA CloudWatch agent not installed
+- Multi-GPU: MAX statistic used across GPU indices
+- Instance state filter: only running instances
+- GPU family filter: non-GPU instances skipped
+- Age guard: instances younger than idle_days skipped
+- Utilisation thresholds: configurable gpu_threshold and cpu_threshold
+- Risk levels: CRITICAL (idle_ratio >= 2.0), HIGH otherwise
+- Active GPU instance not flagged
+- Active CPU instance not flagged (fallback path)
+- CloudWatch errors treated as active (safe default)
+- Permission errors: PermissionError raised on AccessDenied from describe_instances
+- RULE_METADATA and RULE_ID attributes
+"""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+from botocore.exceptions import ClientError
+
+from cleancloud.core.confidence import ConfidenceLevel
+from cleancloud.core.risk import RiskLevel
+from cleancloud.providers.aws.rules.ec2_gpu_idle import (
+    _DEFAULT_MONTHLY_COST,
+    _MONTHLY_COST,
+    RULE_METADATA,
+    _is_gpu_instance,
+    _is_neuron_instance,
+    _list_gpu_metrics,
+    find_idle_gpu_instances,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+NOW = datetime(2025, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+_REGION = "us-east-1"
+_INSTANCE_ID = "i-0abc1234567890def"
+_INSTANCE_TYPE = "p3.2xlarge"
+
+
+def _make_instance(
+    instance_id=_INSTANCE_ID,
+    instance_type=_INSTANCE_TYPE,
+    age_days=30,
+    state="running",
+    tags=None,
+):
+    launch_time = NOW - timedelta(days=age_days)
+    return {
+        "InstanceId": instance_id,
+        "InstanceType": instance_type,
+        "State": {"Name": state},
+        "LaunchTime": launch_time,
+        "Tags": tags or [{"Key": "Name", "Value": "gpu-trainer"}],
+    }
+
+
+def _make_session(instances, gpu_util=None, cpu_util=None, has_gpu_metric=False):
+    """
+    Build a mock boto3 session.
+
+    gpu_util: if not None, NVIDIA CloudWatch agent metrics are available with this max value.
+    cpu_util: avg CPU utilisation returned from AWS/EC2 namespace.
+    has_gpu_metric: whether ListMetrics returns NVIDIA metrics.
+    """
+    session = MagicMock()
+
+    # EC2 client
+    ec2 = MagicMock()
+    paginator = MagicMock()
+    reservations = [{"Instances": instances}] if instances else []
+    paginator.paginate.return_value = [{"Reservations": reservations}]
+    ec2.get_paginator.return_value = paginator
+
+    # CloudWatch client
+    cw = MagicMock()
+
+    # ListMetrics for GPU probe
+    if has_gpu_metric:
+        cw.list_metrics.return_value = {
+            "Metrics": [
+                {
+                    "Namespace": "CWAgent",
+                    "MetricName": "nvidia_smi_utilization_gpu",
+                    "Dimensions": [
+                        {"Name": "InstanceId", "Value": _INSTANCE_ID},
+                        {"Name": "gpu_id", "Value": "0"},
+                    ],
+                }
+            ]
+        }
+    else:
+        cw.list_metrics.return_value = {"Metrics": []}
+
+    # GetMetricStatistics for GPU utilisation
+    if gpu_util is not None:
+        cw.get_metric_statistics.return_value = {
+            "Datapoints": [{"Maximum": gpu_util, "Timestamp": NOW}]
+        }
+    elif cpu_util is not None:
+        cw.get_metric_statistics.return_value = {
+            "Datapoints": [{"Average": cpu_util, "Timestamp": NOW}]
+        }
+    else:
+        cw.get_metric_statistics.return_value = {"Datapoints": []}
+
+    def _client(service, **kwargs):
+        if service == "ec2":
+            return ec2
+        if service == "cloudwatch":
+            return cw
+        return MagicMock()
+
+    session.client.side_effect = _client
+    return session
+
+
+def _run(instances, gpu_util=None, cpu_util=None, has_gpu_metric=False, **kwargs):
+    session = _make_session(
+        instances, gpu_util=gpu_util, cpu_util=cpu_util, has_gpu_metric=has_gpu_metric
+    )
+    with patch("cleancloud.providers.aws.rules.ec2_gpu_idle.datetime") as mock_dt:
+        mock_dt.now.return_value = NOW
+        mock_dt.fromisoformat = datetime.fromisoformat
+        return find_idle_gpu_instances(session, _REGION, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# _is_gpu_instance
+# ---------------------------------------------------------------------------
+
+
+class TestIsGpuInstance:
+    def test_p3_is_gpu(self):
+        assert _is_gpu_instance("p3.2xlarge")
+
+    def test_p4d_is_gpu(self):
+        assert _is_gpu_instance("p4d.24xlarge")
+
+    def test_g4dn_is_gpu(self):
+        assert _is_gpu_instance("g4dn.xlarge")
+
+    def test_g5_is_gpu(self):
+        assert _is_gpu_instance("g5.12xlarge")
+
+    def test_trn1_is_gpu(self):
+        assert _is_gpu_instance("trn1.2xlarge")
+
+    def test_inf2_is_gpu(self):
+        assert _is_gpu_instance("inf2.xlarge")
+
+    def test_t3_is_not_gpu(self):
+        assert not _is_gpu_instance("t3.large")
+
+    def test_m5_is_not_gpu(self):
+        assert not _is_gpu_instance("m5.4xlarge")
+
+    def test_c5_is_not_gpu(self):
+        assert not _is_gpu_instance("c5.xlarge")
+
+
+# ---------------------------------------------------------------------------
+# _list_gpu_metrics
+# ---------------------------------------------------------------------------
+
+
+class TestListGpuMetrics:
+    def test_returns_metrics_list_when_found(self):
+        cw = MagicMock()
+        metrics = [{"MetricName": "nvidia_smi_utilization_gpu", "Dimensions": []}]
+        cw.list_metrics.return_value = {"Metrics": metrics}
+        assert _list_gpu_metrics(cw, "i-abc") == metrics
+
+    def test_returns_empty_list_when_no_metrics(self):
+        cw = MagicMock()
+        cw.list_metrics.return_value = {"Metrics": []}
+        assert _list_gpu_metrics(cw, "i-abc") == []
+
+    def test_returns_empty_list_on_client_error(self):
+        cw = MagicMock()
+        cw.list_metrics.side_effect = ClientError(
+            {"Error": {"Code": "AccessDenied", "Message": "denied"}}, "ListMetrics"
+        )
+        assert _list_gpu_metrics(cw, "i-abc") == []
+
+
+# ---------------------------------------------------------------------------
+# _is_neuron_instance
+# ---------------------------------------------------------------------------
+
+
+class TestIsNeuronInstance:
+    def test_trn1_is_neuron(self):
+        assert _is_neuron_instance("trn1.2xlarge")
+
+    def test_trn2_is_neuron(self):
+        assert _is_neuron_instance("trn2.48xlarge")
+
+    def test_inf2_is_neuron(self):
+        assert _is_neuron_instance("inf2.xlarge")
+
+    def test_dl1_is_neuron(self):
+        assert _is_neuron_instance("dl1.24xlarge")
+
+    def test_p3_is_not_neuron(self):
+        assert not _is_neuron_instance("p3.2xlarge")
+
+    def test_g5_is_not_neuron(self):
+        assert not _is_neuron_instance("g5.xlarge")
+
+
+# ---------------------------------------------------------------------------
+# Core detection
+# ---------------------------------------------------------------------------
+
+
+class TestFindIdleGpuInstances:
+    def test_idle_gpu_instance_flagged_high_confidence(self):
+        """GPU metric available, utilisation below threshold → HIGH confidence."""
+        # age=7, idle_days=7 → idle_ratio=1.0 < 2.0 → HIGH risk (not CRITICAL)
+        findings = _run([_make_instance(age_days=7)], gpu_util=2.0, has_gpu_metric=True)
+        assert len(findings) == 1
+        f = findings[0]
+        assert f.rule_id == "aws.ec2.gpu.idle"
+        assert f.provider == "aws"
+        assert f.resource_id == _INSTANCE_ID
+        assert f.region == _REGION
+        assert f.confidence == ConfidenceLevel.HIGH
+        assert f.risk == RiskLevel.HIGH
+
+    def test_idle_gpu_instance_cpu_fallback_medium_confidence(self):
+        """No GPU metric → CPU fallback → MEDIUM confidence."""
+        findings = _run([_make_instance()], cpu_util=5.0, has_gpu_metric=False)
+        assert len(findings) == 1
+        assert findings[0].confidence == ConfidenceLevel.MEDIUM
+
+    def test_active_gpu_instance_not_flagged(self):
+        """GPU utilisation above threshold → not flagged."""
+        findings = _run([_make_instance()], gpu_util=50.0, has_gpu_metric=True)
+        assert findings == []
+
+    def test_active_cpu_fallback_not_flagged(self):
+        """CPU utilisation above threshold in fallback path → not flagged."""
+        findings = _run([_make_instance()], cpu_util=25.0, has_gpu_metric=False)
+        assert findings == []
+
+    def test_non_gpu_instance_skipped(self):
+        findings = _run(
+            [_make_instance(instance_type="m5.4xlarge")], gpu_util=0.0, has_gpu_metric=True
+        )
+        assert findings == []
+
+    def test_stopped_instance_skipped(self):
+        findings = _run([_make_instance(state="stopped")], gpu_util=0.0, has_gpu_metric=True)
+        assert findings == []
+
+    def test_young_instance_skipped(self):
+        """Instance younger than idle_days (7) is skipped."""
+        findings = _run([_make_instance(age_days=3)], gpu_util=0.0, has_gpu_metric=True)
+        assert findings == []
+
+    def test_exactly_at_idle_days_not_skipped(self):
+        findings = _run([_make_instance(age_days=7)], gpu_util=0.0, has_gpu_metric=True)
+        assert len(findings) == 1
+
+    def test_critical_risk_when_idle_ratio_ge_2(self):
+        """idle_ratio = age_days / idle_days. age=30, idle_days=7 → 30/7 ≈ 4.3 >= 2."""
+        findings = _run([_make_instance(age_days=30)], gpu_util=1.0, has_gpu_metric=True)
+        assert len(findings) == 1
+        assert findings[0].risk == RiskLevel.CRITICAL
+
+    def test_high_risk_when_idle_ratio_lt_2(self):
+        """age=7, idle_days=7 → ratio=1.0 < 2 → HIGH."""
+        findings = _run([_make_instance(age_days=7)], gpu_util=1.0, has_gpu_metric=True)
+        assert len(findings) == 1
+        assert findings[0].risk == RiskLevel.HIGH
+
+    def test_empty_instances_returns_no_findings(self):
+        findings = _run([])
+        assert findings == []
+
+    def test_cost_estimate_in_finding(self):
+        findings = _run(
+            [_make_instance(instance_type="p3.2xlarge")], gpu_util=0.0, has_gpu_metric=True
+        )
+        assert len(findings) == 1
+        assert findings[0].estimated_monthly_cost_usd == _MONTHLY_COST["p3.2xlarge"]
+
+    def test_unknown_instance_type_uses_default_cost(self):
+        # p3.custom matches the p3. GPU family prefix but is not in the cost table
+        findings = _run(
+            [_make_instance(instance_type="p3.custom")], gpu_util=0.0, has_gpu_metric=True
+        )
+        assert len(findings) == 1
+        assert findings[0].estimated_monthly_cost_usd == _DEFAULT_MONTHLY_COST
+
+    def test_gpu_signal_in_signals_used(self):
+        findings = _run([_make_instance()], gpu_util=2.5, has_gpu_metric=True)
+        signals = findings[0].evidence.signals_used
+        assert any("GPU" in s for s in signals)
+
+    def test_cpu_fallback_signal_in_signals_used(self):
+        findings = _run([_make_instance()], cpu_util=5.0, has_gpu_metric=False)
+        signals = findings[0].evidence.signals_used
+        assert any("NVIDIA CloudWatch agent not detected" in s for s in signals)
+
+    def test_neuron_instance_uses_neuron_signal_text(self):
+        findings = _run(
+            [_make_instance(instance_type="trn1.2xlarge")],
+            cpu_util=5.0,
+            has_gpu_metric=False,
+        )
+        assert len(findings) == 1
+        signals = findings[0].evidence.signals_used
+        assert any("Neuron instance" in s for s in signals)
+        assert not any("NVIDIA CloudWatch agent" in s for s in signals)
+
+    def test_g6e_cost_not_default(self):
+        findings = _run([_make_instance(instance_type="g6e.48xlarge")], cpu_util=5.0)
+        assert len(findings) == 1
+        assert findings[0].estimated_monthly_cost_usd == 18_000.0
+
+    def test_trn2_cost_not_default(self):
+        findings = _run([_make_instance(instance_type="trn2.48xlarge")], cpu_util=5.0)
+        assert len(findings) == 1
+        assert findings[0].estimated_monthly_cost_usd == 110_000.0
+
+    def test_custom_gpu_threshold(self):
+        """gpu_threshold=10 → instance at 8% GPU util flagged."""
+        findings = _run([_make_instance()], gpu_util=8.0, has_gpu_metric=True, gpu_threshold=10.0)
+        assert len(findings) == 1
+
+    def test_custom_cpu_threshold(self):
+        """cpu_threshold=20 → instance at 15% CPU flagged."""
+        findings = _run([_make_instance()], cpu_util=15.0, has_gpu_metric=False, cpu_threshold=20.0)
+        assert len(findings) == 1
+
+    def test_cloudwatch_error_treated_as_active(self):
+        """CloudWatch failure on GPU stats → None returned → instance not flagged."""
+        session = _make_session([_make_instance()], has_gpu_metric=True)
+        cw = session.client("cloudwatch")
+        # list_metrics returns metrics but get_metric_statistics raises
+        cw.list_metrics.return_value = {
+            "Metrics": [
+                {
+                    "Namespace": "CWAgent",
+                    "MetricName": "nvidia_smi_utilization_gpu",
+                    "Dimensions": [{"Name": "InstanceId", "Value": _INSTANCE_ID}],
+                }
+            ]
+        }
+        cw.get_metric_statistics.side_effect = ClientError(
+            {"Error": {"Code": "ThrottlingException", "Message": "throttled"}},
+            "GetMetricStatistics",
+        )
+        with patch("cleancloud.providers.aws.rules.ec2_gpu_idle.datetime") as mock_dt:
+            mock_dt.now.return_value = NOW
+            mock_dt.fromisoformat = datetime.fromisoformat
+            findings = find_idle_gpu_instances(session, _REGION)
+        assert findings == []
+
+    def test_permission_error_on_describe_instances(self):
+        session = MagicMock()
+        ec2 = MagicMock()
+        paginator = MagicMock()
+        paginator.paginate.side_effect = ClientError(
+            {"Error": {"Code": "UnauthorizedOperation", "Message": "denied"}},
+            "DescribeInstances",
+        )
+        ec2.get_paginator.return_value = paginator
+        session.client.return_value = ec2
+
+        with pytest.raises(PermissionError, match="ec2:DescribeInstances"):
+            find_idle_gpu_instances(session, _REGION)
+
+    def test_details_include_idle_signal_source(self):
+        findings = _run([_make_instance()], gpu_util=1.0, has_gpu_metric=True)
+        assert findings[0].details["idle_signal"] == "gpu_utilisation"
+
+    def test_details_include_cpu_fallback_signal_source(self):
+        findings = _run([_make_instance()], cpu_util=5.0, has_gpu_metric=False)
+        assert findings[0].details["idle_signal"] == "cpu_utilisation_fallback"
+
+    def test_details_include_gpu_metric_available_flag(self):
+        findings = _run([_make_instance()], gpu_util=1.0, has_gpu_metric=True)
+        assert findings[0].details["gpu_metric_available"] is True
+
+    def test_rule_metadata_and_rule_id(self):
+        assert RULE_METADATA["id"] == "aws.ec2.gpu.idle"
+        assert RULE_METADATA["category"] == "ai"
+        assert find_idle_gpu_instances.RULE_ID == "aws.ec2.gpu.idle"
+
+    def test_multiple_gpu_instances(self):
+        inst1 = _make_instance(instance_id="i-aaa", instance_type="p3.2xlarge")
+        inst2 = _make_instance(instance_id="i-bbb", instance_type="g5.xlarge")
+        session = MagicMock()
+        ec2 = MagicMock()
+        paginator = MagicMock()
+        paginator.paginate.return_value = [{"Reservations": [{"Instances": [inst1, inst2]}]}]
+        ec2.get_paginator.return_value = paginator
+        cw = MagicMock()
+        cw.list_metrics.return_value = {"Metrics": []}
+        cw.get_metric_statistics.return_value = {"Datapoints": [{"Average": 3.0, "Timestamp": NOW}]}
+
+        def _client(service, **kwargs):
+            return ec2 if service == "ec2" else cw
+
+        session.client.side_effect = _client
+        with patch("cleancloud.providers.aws.rules.ec2_gpu_idle.datetime") as mock_dt:
+            mock_dt.now.return_value = NOW
+            mock_dt.fromisoformat = datetime.fromisoformat
+            findings = find_idle_gpu_instances(session, _REGION)
+        assert len(findings) == 2

--- a/tests/e2e/aws/test_aws_ai_rules_smoke.py
+++ b/tests/e2e/aws/test_aws_ai_rules_smoke.py
@@ -4,12 +4,19 @@ import boto3
 import pytest
 
 from cleancloud.core.finding import Finding
+from cleancloud.providers.aws.rules.ec2_gpu_idle import find_idle_gpu_instances
 from cleancloud.providers.aws.rules.sagemaker_endpoint_idle import (
     find_idle_sagemaker_endpoints,
 )
 from cleancloud.providers.aws.rules.sagemaker_notebook_idle import (
     find_idle_sagemaker_notebooks,
 )
+
+_AWS_AI_RULE_IDS = {
+    "aws.sagemaker.endpoint.idle",
+    "aws.sagemaker.notebook.idle",
+    "aws.ec2.gpu.idle",
+}
 
 
 @pytest.mark.e2e
@@ -21,6 +28,7 @@ def test_aws_ai_rules_run_without_error():
     rules = [
         find_idle_sagemaker_endpoints,
         find_idle_sagemaker_notebooks,
+        find_idle_gpu_instances,
     ]
 
     all_results = []
@@ -34,10 +42,33 @@ def test_aws_ai_rules_run_without_error():
     for f in all_results:
         assert isinstance(f, Finding)
         assert f.provider == "aws"
-        assert f.rule_id.startswith("aws.sagemaker.")
+        assert f.rule_id in _AWS_AI_RULE_IDS
         assert f.resource_id
         assert f.region
         assert f.detected_at and isinstance(f.detected_at, datetime)
+
+
+@pytest.mark.e2e
+@pytest.mark.aws
+def test_ec2_gpu_idle_returns_list_of_findings():
+    """Smoke test: rule runs without error and returns typed findings."""
+    session = boto3.Session()
+    findings = find_idle_gpu_instances(session, "us-east-1")
+
+    assert isinstance(findings, list)
+    for f in findings:
+        assert isinstance(f, Finding)
+        assert f.rule_id == "aws.ec2.gpu.idle"
+        assert f.resource_type == "aws.ec2.instance"
+        assert f.provider == "aws"
+        assert f.resource_id
+        assert f.region == "us-east-1"
+        assert f.detected_at and isinstance(f.detected_at, datetime)
+        assert f.estimated_monthly_cost_usd > 0
+        assert f.confidence.value in ("high", "medium")
+        assert f.risk.value in ("critical", "high")
+        assert f.details["gpu_metric_available"] in (True, False)
+        assert f.details["idle_signal"] in ("gpu_utilisation", "cpu_utilisation_fallback")
 
 
 @pytest.mark.e2e


### PR DESCRIPTION
@javvaji-devops please review:

 Rule: aws.ec2.gpu.idle — Idle EC2 GPU/Accelerator Instance Detection                                                                                                                                                             
                                                                                                                                                                                                                                   
  Detects raw EC2 GPU instances left running with no workload. A p4d.24xlarge costs ~$23K/month whether or not a job is running — this rule catches the gap between "job finished" and "instance stopped".                         
                                                                                                                                                                                                                                   
  What's covered: p2/p3/p4/p5 (NVIDIA K80→H100), g4/g5/g6/g6e/gr6 (T4→L40S), trn1/trn2 (Trainium), inf1/inf2 (Inferentia), dl1/dl2q — 20 instance families, 60+ instance types.                                                    
                                                                                                                                                                                                                                   
  Two-tier detection:                                                                                                                                                                                                              
  - HIGH confidence — NVIDIA CloudWatch agent installed: reads nvidia_smi_utilization_gpu from CWAgent namespace. Uses MAX statistic across all GPU indices so a single active GPU on an 8-GPU instance (p4d, p5) isn't masked by averaging.                                                                                                                                                                                                                       
  - MEDIUM confidence — No agent: falls back to CPUUtilization from AWS/EC2. Neuron instances (Trainium/Inferentia) always land here by design — they use AWS Neuron SDK, not NVIDIA CUDA, so the GPU metric is never published.
                                                                                                                                                                                                                                   
  Risk escalation: CRITICAL when age_days / idle_days ≥ 2.0 (e.g. instance running 14+ days at 7-day threshold), HIGH otherwise.                                                                                                   
                                                                                                                                                                                                                                   
  Configurable: idle_days (default 7), gpu_threshold (default 5%), cpu_threshold (default 10%).                                                                                                                                    
                                                                                                                                                                                                                                   
  IAM additions: ec2:DescribeInstances, cloudwatch:GetMetricStatistics, cloudwatch:ListMetrics — all added to ai-readonly.json and the Terraform/CloudFormation deploy templates.                                                  
  
