### PR TITLE
User Feedback: Heavy install footprint

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -66,7 +66,9 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
-          build-args: CLEANCLOUD_VERSION=${{ steps.version.outputs.CLEANCLOUD_VERSION }}
+          build-args: |
+            CLEANCLOUD_VERSION=${{ steps.version.outputs.CLEANCLOUD_VERSION }}
+            CLEANCLOUD_EXTRAS=all
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/main-validation.yml
+++ b/.github/workflows/main-validation.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]"
+          pip install -e ".[all,dev]"
 
 #      - name: Verify imports
 #        run: |
@@ -61,7 +61,7 @@ jobs:
       - name: Install CleanCloud
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]"
+          pip install -e ".[all,dev]"
 
       # AWS via OIDC (no static secrets)
       - name: Configure AWS credentials (OIDC)
@@ -104,7 +104,7 @@ jobs:
       - name: Install CleanCloud
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]"
+          pip install -e ".[all,dev]"
 
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4
@@ -146,7 +146,7 @@ jobs:
       - name: Install CleanCloud
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]"
+          pip install -e ".[all,dev]"
 
       - name: Azure Login via OIDC
         uses: azure/login@v2
@@ -191,7 +191,7 @@ jobs:
       - name: Install CleanCloud
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]"
+          pip install -e ".[all,dev]"
 
       - name: Azure Login via OIDC (no subscription pin — scans all)
         uses: azure/login@v2
@@ -233,7 +233,7 @@ jobs:
       - name: Install CleanCloud
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]"
+          pip install -e ".[all,dev]"
 
       - name: Authenticate to GCP (Workload Identity Federation)
         uses: google-github-actions/auth@v2

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]"
+          pip install -e ".[all,dev]"
 
       # AWS via OIDC (no static secrets)
       - name: Configure AWS credentials (OIDC)
@@ -149,7 +149,7 @@ jobs:
       - name: Install CleanCloud
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]"
+          pip install -e ".[all,dev]"
 
       # AWS via OIDC (matches client CI usage)
       - name: Configure AWS credentials (OIDC)
@@ -194,7 +194,7 @@ jobs:
       - name: Install CleanCloud
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]"
+          pip install -e ".[all,dev]"
 
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4
@@ -235,7 +235,7 @@ jobs:
       - name: Install CleanCloud
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]"
+          pip install -e ".[all,dev]"
 
       - name: Azure Login via OIDC
         uses: azure/login@v2
@@ -281,7 +281,7 @@ jobs:
       - name: Install CleanCloud
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]"
+          pip install -e ".[all,dev]"
 
       - name: Azure Login via OIDC (no subscription pin — scans all)
         uses: azure/login@v2
@@ -322,7 +322,7 @@ jobs:
       - name: Install CleanCloud
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]"
+          pip install -e ".[all,dev]"
 
       - name: Authenticate to GCP (Workload Identity Federation)
         uses: google-github-actions/auth@v2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,9 +53,8 @@ cd cleancloud
 python -m venv venv
 source venv/bin/activate  # On Windows: venv\Scripts\activate
 
-# Install dependencies
-pip install -e .
-pip install -r requirements-dev.txt  # If exists
+# Install with all cloud SDKs and dev dependencies
+pip install -e '.[all,dev]'
 ```
 
 ### 3. Run Tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,11 @@ RUN apk update && apk upgrade && rm -rf /var/cache/apk/* \
     && pip install --upgrade pip
 
 ARG CLEANCLOUD_VERSION
+ARG CLEANCLOUD_EXTRAS=all
 RUN if [ -n "${CLEANCLOUD_VERSION}" ]; then \
-        pip install cleancloud==${CLEANCLOUD_VERSION}; \
+        pip install "cleancloud[${CLEANCLOUD_EXTRAS}]==${CLEANCLOUD_VERSION}"; \
     else \
-        pip install cleancloud; \
+        pip install "cleancloud[${CLEANCLOUD_EXTRAS}]"; \
     fi
 
 ENTRYPOINT ["cleancloud"]

--- a/README.fr.md
+++ b/README.fr.md
@@ -22,14 +22,16 @@ CleanCloud vous indique exactement ce qu'il faut supprimer dans votre cloud — 
 ## Démarrage rapide
 
 ```bash
-pipx install cleancloud
-cleancloud demo                      # visualisez des findings — aucun credential requis
-cleancloud demo --category ai        # findings IA/ML (SageMaker, AML, Vertex AI)
+pipx install cleancloud                  # core uniquement — sans SDK cloud
+cleancloud demo                          # visualisez des findings — aucun credential requis
+cleancloud demo --category ai            # findings IA/ML (SageMaker, AML, Vertex AI)
 ```
 
-Scannez votre cloud :
+Scannez votre cloud (installez le SDK de votre fournisseur) :
 
 ```bash
+pipx install 'cleancloud[aws]'           # ou [azure], [gcp], [all]
+
 cleancloud scan --provider aws --all-regions
 cleancloud scan --provider azure
 cleancloud scan --provider gcp --all-projects
@@ -244,7 +246,7 @@ Entièrement en lecture seule. Sûr pour la production et les environnements ré
 ## Démarrage
 
 ```bash
-pipx install cleancloud
+pipx install 'cleancloud[all]'                     # tous les SDK cloud (AWS + Azure + GCP)
 cleancloud demo                                    # aucun credential requis
 ```
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -22,20 +22,16 @@ CleanCloud vous indique exactement ce qu'il faut supprimer dans votre cloud — 
 ## Démarrage rapide
 
 ```bash
-pipx install cleancloud                  # core uniquement — sans SDK cloud
-cleancloud demo                          # visualisez des findings — aucun credential requis
-cleancloud demo --category ai            # findings IA/ML (SageMaker, AML, Vertex AI)
-```
+# Essayez sans credentials :
+pipx install cleancloud
+cleancloud demo
+cleancloud demo --category ai
 
-Scannez votre cloud (installez le SDK de votre fournisseur) :
-
-```bash
+# Prêt à scanner votre cloud ? Ajoutez votre fournisseur :
 pipx install 'cleancloud[aws]'           # ou [azure], [gcp], [all]
-
 cleancloud scan --provider aws --all-regions
 cleancloud scan --provider azure
 cleancloud scan --provider gcp --all-projects
-cleancloud scan --provider aws --category ai   # détectez les endpoints SageMaker inactifs
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -22,14 +22,16 @@ CleanCloud tells you exactly what to delete in your cloud — with cost per reso
 ## Quick Start
 
 ```bash
-pipx install cleancloud
-cleancloud demo                      # see sample findings — no credentials needed
-cleancloud demo --category ai        # see AI/ML waste findings (SageMaker, AML, Vertex AI)
+pipx install cleancloud                 # core only — no cloud SDKs
+cleancloud demo                         # see sample findings — no credentials needed
+cleancloud demo --category ai           # see AI/ML waste findings (SageMaker, AML, Vertex AI)
 ```
 
-Scan your cloud:
+Scan your cloud (install the SDK for your provider):
 
 ```bash
+pipx install 'cleancloud[aws]'          # or [azure], [gcp], [all]
+
 cleancloud scan --provider aws --all-regions
 cleancloud scan --provider azure
 cleancloud scan --provider gcp --all-projects
@@ -244,7 +246,7 @@ Fully read-only. Safe for production and regulated environments.
 ## Get Started
 
 ```bash
-pipx install cleancloud
+pipx install 'cleancloud[all]'            # all cloud SDKs (AWS + Azure + GCP)
 cleancloud demo                           # no credentials needed
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,20 +22,16 @@ CleanCloud tells you exactly what to delete in your cloud — with cost per reso
 ## Quick Start
 
 ```bash
-pipx install cleancloud                 # core only — no cloud SDKs
-cleancloud demo                         # see sample findings — no credentials needed
-cleancloud demo --category ai           # see AI/ML waste findings (SageMaker, AML, Vertex AI)
-```
+# Try it — no credentials needed:
+pipx install cleancloud
+cleancloud demo
+cleancloud demo --category ai
 
-Scan your cloud (install the SDK for your provider):
-
-```bash
+# Ready to scan your cloud? Add your provider:
 pipx install 'cleancloud[aws]'          # or [azure], [gcp], [all]
-
 cleancloud scan --provider aws --all-regions
 cleancloud scan --provider azure
 cleancloud scan --provider gcp --all-projects
-cleancloud scan --provider aws --category ai   # detect idle SageMaker endpoints
 ```
 
 ---

--- a/cleancloud/cli.py
+++ b/cleancloud/cli.py
@@ -42,7 +42,7 @@ def _version_info():
 
     if not providers:
         lines.append("")
-        lines.append("Install providers: pipx install cleancloud --force")
+        lines.append("Install providers: pip install 'cleancloud[aws]'  # or [azure], [gcp], [all]")
 
     return "\n".join(lines)
 

--- a/cleancloud/doctor/runner.py
+++ b/cleancloud/doctor/runner.py
@@ -5,6 +5,7 @@ from cleancloud.doctor.common import DoctorError, info, success
 
 try:
     from cleancloud.doctor.aws import run_aws_ai_doctor, run_aws_doctor
+
     _AWS_DOCTOR_AVAILABLE = True
 except ImportError:
     _AWS_DOCTOR_AVAILABLE = False
@@ -12,6 +13,7 @@ except ImportError:
 
 try:
     from cleancloud.doctor.azure import run_azure_ai_doctor, run_azure_doctor
+
     _AZURE_DOCTOR_AVAILABLE = True
 except ImportError:
     _AZURE_DOCTOR_AVAILABLE = False
@@ -19,12 +21,17 @@ except ImportError:
 
 try:
     from cleancloud.doctor.gcp import run_gcp_ai_doctor, run_gcp_doctor
+
     _GCP_DOCTOR_AVAILABLE = True
 except ImportError:
     _GCP_DOCTOR_AVAILABLE = False
     run_gcp_doctor = run_gcp_ai_doctor = None  # type: ignore[assignment]
 
-_DOCTOR_AVAILABLE = {"aws": lambda: _AWS_DOCTOR_AVAILABLE, "azure": lambda: _AZURE_DOCTOR_AVAILABLE, "gcp": lambda: _GCP_DOCTOR_AVAILABLE}
+_DOCTOR_AVAILABLE = {
+    "aws": lambda: _AWS_DOCTOR_AVAILABLE,
+    "azure": lambda: _AZURE_DOCTOR_AVAILABLE,
+    "gcp": lambda: _GCP_DOCTOR_AVAILABLE,
+}
 _INSTALL_HINTS = {
     "aws": "pip install 'cleancloud[aws]'",
     "azure": "pip install 'cleancloud[azure]'",

--- a/cleancloud/doctor/runner.py
+++ b/cleancloud/doctor/runner.py
@@ -1,10 +1,35 @@
 import sys
 from typing import Optional
 
-from cleancloud.doctor.aws import run_aws_ai_doctor, run_aws_doctor
-from cleancloud.doctor.azure import run_azure_ai_doctor, run_azure_doctor
 from cleancloud.doctor.common import DoctorError, info, success
-from cleancloud.doctor.gcp import run_gcp_ai_doctor, run_gcp_doctor
+
+try:
+    from cleancloud.doctor.aws import run_aws_ai_doctor, run_aws_doctor
+    _AWS_DOCTOR_AVAILABLE = True
+except ImportError:
+    _AWS_DOCTOR_AVAILABLE = False
+    run_aws_doctor = run_aws_ai_doctor = None  # type: ignore[assignment]
+
+try:
+    from cleancloud.doctor.azure import run_azure_ai_doctor, run_azure_doctor
+    _AZURE_DOCTOR_AVAILABLE = True
+except ImportError:
+    _AZURE_DOCTOR_AVAILABLE = False
+    run_azure_doctor = run_azure_ai_doctor = None  # type: ignore[assignment]
+
+try:
+    from cleancloud.doctor.gcp import run_gcp_ai_doctor, run_gcp_doctor
+    _GCP_DOCTOR_AVAILABLE = True
+except ImportError:
+    _GCP_DOCTOR_AVAILABLE = False
+    run_gcp_doctor = run_gcp_ai_doctor = None  # type: ignore[assignment]
+
+_DOCTOR_AVAILABLE = {"aws": lambda: _AWS_DOCTOR_AVAILABLE, "azure": lambda: _AZURE_DOCTOR_AVAILABLE, "gcp": lambda: _GCP_DOCTOR_AVAILABLE}
+_INSTALL_HINTS = {
+    "aws": "pip install 'cleancloud[aws]'",
+    "azure": "pip install 'cleancloud[azure]'",
+    "gcp": "pip install 'cleancloud[gcp]'",
+}
 
 
 def run_doctor(
@@ -46,6 +71,14 @@ def run_doctor(
 
     # Run checks for each provider
     for p in providers_to_check:
+        if not _DOCTOR_AVAILABLE.get(p, lambda: True)():
+            hint = _INSTALL_HINTS.get(p, "pip install 'cleancloud[all]'")
+            info(f"Provider '{p}' SDK is not installed. Install it with: {hint}")
+            results[p] = {"status": "failed", "error": f"SDK not installed — {hint}"}
+            if len(providers_to_check) == 1:
+                sys.exit(1)
+            continue
+
         try:
             if p == "aws":
                 if category == "ai":

--- a/cleancloud/scan/command.py
+++ b/cleancloud/scan/command.py
@@ -4,7 +4,13 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import List, Optional
 
-import botocore.exceptions
+try:
+    import botocore.exceptions
+    _NoCredentialsError = botocore.exceptions.NoCredentialsError
+except ImportError:
+    class _NoCredentialsError(Exception):  # type: ignore[no-redef]
+        """Never raised — placeholder so the except clause compiles without boto3."""
+
 import click
 import yaml
 
@@ -41,33 +47,72 @@ from cleancloud.policy.exit_policy import (
     EXIT_POLICY_VIOLATION,
     determine_exit_code,
 )
-from cleancloud.providers.aws.multi_account import (
-    AccountScanResult,
-    discover_org_accounts,
-    scan_multiple_accounts,
-)
-from cleancloud.providers.aws.scan import (
-    AWS_AI_RULES,
-    AWS_RULE_MAP,
-    AWS_RULE_MAP_AI,
-    AWS_RULES,
-    scan_aws_with_region_selection,
-)
-from cleancloud.providers.azure.scan import (
-    AZURE_AI_RULES,
-    AZURE_RULE_MAP,
-    AZURE_RULE_MAP_AI,
-    AZURE_RULES,
-    scan_azure_with_region_selection,
-)
-from cleancloud.providers.gcp.scan import (
-    GCP_AI_RULES,
-    GCP_RULE_MAP,
-    GCP_RULE_MAP_AI,
-    GCP_RULES,
-    ProjectScanResult,
-    scan_gcp_with_project_selection,
-)
+try:
+    from cleancloud.providers.aws.multi_account import (
+        AccountScanResult,
+        discover_org_accounts,
+        scan_multiple_accounts,
+    )
+    from cleancloud.providers.aws.scan import (
+        AWS_AI_RULES,
+        AWS_RULE_MAP,
+        AWS_RULE_MAP_AI,
+        AWS_RULES,
+        scan_aws_with_region_selection,
+    )
+    _AWS_AVAILABLE = True
+except ImportError:
+    _AWS_AVAILABLE = False
+    AWS_RULES = AWS_AI_RULES = []
+    AWS_RULE_MAP = AWS_RULE_MAP_AI = {}
+    AccountScanResult = None
+    discover_org_accounts = scan_multiple_accounts = scan_aws_with_region_selection = None
+
+try:
+    from cleancloud.providers.azure.scan import (
+        AZURE_AI_RULES,
+        AZURE_RULE_MAP,
+        AZURE_RULE_MAP_AI,
+        AZURE_RULES,
+        scan_azure_with_region_selection,
+    )
+    _AZURE_AVAILABLE = True
+except ImportError:
+    _AZURE_AVAILABLE = False
+    AZURE_RULES = AZURE_AI_RULES = []
+    AZURE_RULE_MAP = AZURE_RULE_MAP_AI = {}
+    scan_azure_with_region_selection = None
+
+try:
+    from cleancloud.providers.gcp.scan import (
+        GCP_AI_RULES,
+        GCP_RULE_MAP,
+        GCP_RULE_MAP_AI,
+        GCP_RULES,
+        ProjectScanResult,
+        scan_gcp_with_project_selection,
+    )
+    _GCP_AVAILABLE = True
+except ImportError:
+    _GCP_AVAILABLE = False
+    GCP_RULES = GCP_AI_RULES = []
+    GCP_RULE_MAP = GCP_RULE_MAP_AI = {}
+    ProjectScanResult = None
+    scan_gcp_with_project_selection = None
+
+_PROVIDER_AVAILABLE = {"aws": lambda: _AWS_AVAILABLE, "azure": lambda: _AZURE_AVAILABLE, "gcp": lambda: _GCP_AVAILABLE}
+_INSTALL_HINTS = {
+    "aws": "pip install 'cleancloud[aws]'",
+    "azure": "pip install 'cleancloud[azure]'",
+    "gcp": "pip install 'cleancloud[gcp]'",
+}
+
+
+def _require_provider(provider: str) -> None:
+    if not _PROVIDER_AVAILABLE.get(provider, lambda: True)():
+        click.echo(f"Provider '{provider}' SDK is not installed.")
+        click.echo(f"Install it with: {_INSTALL_HINTS.get(provider, 'pip install cleancloud[all]')}")
+        sys.exit(EXIT_ERROR)
 
 
 @click.command("scan")
@@ -287,6 +332,8 @@ def scan(
         provider = cfg.scan.provider
     if provider is None:
         raise click.UsageError("--provider is required (or set scan.provider in cleancloud.yaml)")
+
+    _require_provider(provider)
 
     # Resolve regions for AWS: CLI flags > scan.regions in config > error (handled in validate)
     if provider == "aws" and not region and not all_regions and cfg.scan and cfg.scan.regions:
@@ -849,7 +896,7 @@ def scan(
             click.echo("Run `cleancloud doctor --provider azure` to diagnose.")
         sys.exit(EXIT_PERMISSION_ERROR)
 
-    except botocore.exceptions.NoCredentialsError:
+    except _NoCredentialsError:
         click.echo()
         click.echo("Authentication failed — no AWS credentials found.")
         click.echo()

--- a/cleancloud/scan/command.py
+++ b/cleancloud/scan/command.py
@@ -6,10 +6,13 @@ from typing import List, Optional
 
 try:
     import botocore.exceptions
+
     _NoCredentialsError = botocore.exceptions.NoCredentialsError
 except ImportError:
+
     class _NoCredentialsError(Exception):  # type: ignore[no-redef]
         """Never raised — placeholder so the except clause compiles without boto3."""
+
 
 import click
 import yaml
@@ -47,6 +50,7 @@ from cleancloud.policy.exit_policy import (
     EXIT_POLICY_VIOLATION,
     determine_exit_code,
 )
+
 try:
     from cleancloud.providers.aws.multi_account import (
         AccountScanResult,
@@ -60,6 +64,7 @@ try:
         AWS_RULES,
         scan_aws_with_region_selection,
     )
+
     _AWS_AVAILABLE = True
 except ImportError:
     _AWS_AVAILABLE = False
@@ -76,6 +81,7 @@ try:
         AZURE_RULES,
         scan_azure_with_region_selection,
     )
+
     _AZURE_AVAILABLE = True
 except ImportError:
     _AZURE_AVAILABLE = False
@@ -92,6 +98,7 @@ try:
         ProjectScanResult,
         scan_gcp_with_project_selection,
     )
+
     _GCP_AVAILABLE = True
 except ImportError:
     _GCP_AVAILABLE = False
@@ -100,7 +107,11 @@ except ImportError:
     ProjectScanResult = None
     scan_gcp_with_project_selection = None
 
-_PROVIDER_AVAILABLE = {"aws": lambda: _AWS_AVAILABLE, "azure": lambda: _AZURE_AVAILABLE, "gcp": lambda: _GCP_AVAILABLE}
+_PROVIDER_AVAILABLE = {
+    "aws": lambda: _AWS_AVAILABLE,
+    "azure": lambda: _AZURE_AVAILABLE,
+    "gcp": lambda: _GCP_AVAILABLE,
+}
 _INSTALL_HINTS = {
     "aws": "pip install 'cleancloud[aws]'",
     "azure": "pip install 'cleancloud[azure]'",
@@ -111,7 +122,9 @@ _INSTALL_HINTS = {
 def _require_provider(provider: str) -> None:
     if not _PROVIDER_AVAILABLE.get(provider, lambda: True)():
         click.echo(f"Provider '{provider}' SDK is not installed.")
-        click.echo(f"Install it with: {_INSTALL_HINTS.get(provider, 'pip install cleancloud[all]')}")
+        click.echo(
+            f"Install it with: {_INSTALL_HINTS.get(provider, 'pip install cleancloud[all]')}"
+        )
         sys.exit(EXIT_ERROR)
 
 

--- a/docs/aws.md
+++ b/docs/aws.md
@@ -291,7 +291,7 @@ jobs:
 
       - name: Validate AWS permissions
         run: |
-          pip install cleancloud
+          pip install 'cleancloud[aws]'
           cleancloud doctor --provider aws --region us-east-1
 ```
 

--- a/docs/azure.md
+++ b/docs/azure.md
@@ -149,7 +149,7 @@ jobs:
 
       - name: Validate Azure permissions
         run: |
-          pip install cleancloud
+          pip install 'cleancloud[azure]'
           cleancloud doctor --provider azure
 ```
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -45,7 +45,7 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/CleanCloudCIReadOnly
           aws-region: us-east-1
-      - run: pip install cleancloud
+      - run: pip install 'cleancloud[aws]'
       - run: cleancloud scan --provider aws --all-regions --fail-on-confidence HIGH
 ```
 
@@ -66,7 +66,7 @@ jobs:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-      - run: pip install cleancloud
+      - run: pip install 'cleancloud[azure]'
       - run: cleancloud scan --provider azure --fail-on-confidence HIGH
 ```
 
@@ -86,7 +86,7 @@ jobs:
         with:
           workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
-      - run: pip install cleancloud
+      - run: pip install 'cleancloud[gcp]'
       - run: cleancloud scan --provider gcp --all-projects --fail-on-confidence HIGH
 ```
 
@@ -527,7 +527,7 @@ jobs:
           aws-region: us-east-1
 
       - name: Install CleanCloud
-        run: pip install cleancloud
+        run: pip install 'cleancloud[aws]'
 
       - name: Validate credentials
         run: cleancloud doctor --provider aws
@@ -579,7 +579,7 @@ jobs:
           aws-region: us-east-1
 
       - name: Install CleanCloud
-        run: pip install cleancloud
+        run: pip install 'cleancloud[aws]'
 
       - name: Validate AI permissions
         run: cleancloud doctor --provider aws --category ai
@@ -635,7 +635,7 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Install CleanCloud
-        run: pip install cleancloud
+        run: pip install 'cleancloud[azure]'
 
       - name: Validate AI permissions
         run: cleancloud doctor --provider azure --category ai
@@ -689,7 +689,7 @@ jobs:
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
       - name: Install CleanCloud
-        run: pip install cleancloud
+        run: pip install 'cleancloud[gcp]'
 
       - name: Validate AI permissions
         run: cleancloud doctor --provider gcp --project ${{ vars.GCP_PROJECT_ID }} --category ai
@@ -747,7 +747,7 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Install CleanCloud
-        run: pip install cleancloud
+        run: pip install 'cleancloud[azure]'
 
       - name: Validate credentials
         run: |
@@ -806,7 +806,7 @@ jobs:
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
       - name: Install CleanCloud
-        run: pip install cleancloud
+        run: pip install 'cleancloud[gcp]'
 
       - name: Validate credentials
         run: cleancloud doctor --provider gcp --project ${{ vars.GCP_PROJECT_ID }}
@@ -868,7 +868,7 @@ jobs:
           aws-region: us-east-1
 
       - name: Install CleanCloud
-        run: pip install cleancloud
+        run: pip install 'cleancloud[aws]'
 
       - name: Scan AWS
         run: |
@@ -901,7 +901,7 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Install CleanCloud
-        run: pip install cleancloud
+        run: pip install 'cleancloud[azure]'
 
       - name: Scan Azure
         run: |
@@ -932,7 +932,7 @@ jobs:
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
       - name: Install CleanCloud
-        run: pip install cleancloud
+        run: pip install 'cleancloud[gcp]'
 
       - name: Scan GCP
         run: |
@@ -1246,7 +1246,7 @@ jobs:
           aws-region: us-east-1
 
       - name: Install CleanCloud
-        run: pip install cleancloud
+        run: pip install 'cleancloud[aws]'
 
       - name: Scan all accounts
         run: |
@@ -1322,7 +1322,7 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Install CleanCloud
-        run: pip install cleancloud
+        run: pip install 'cleancloud[azure]'
 
       - name: Scan all subscriptions
         run: |
@@ -1456,7 +1456,7 @@ jobs:
   weekly-scan:
     steps:
       - name: Install CleanCloud
-        run: pip install cleancloud
+        run: pip install 'cleancloud[aws]'
 
       - name: Run comprehensive scan
         run: |
@@ -1647,7 +1647,7 @@ Coming soon. For now, use Azure CLI task with manual commands:
     scriptType: 'bash'
     scriptLocation: 'inlineScript'
     inlineScript: |
-      pip install cleancloud
+      pip install 'cleancloud[azure]'
       cleancloud scan --provider azure --output json --output-file results.json
 ```
 

--- a/docs/gcp.md
+++ b/docs/gcp.md
@@ -211,7 +211,7 @@ jobs:
 
       - name: Validate credentials
         run: |
-          pip install cleancloud
+          pip install 'cleancloud[gcp]'
           cleancloud doctor --provider gcp --project ${{ vars.GCP_PROJECT_ID }}
 
       - name: Run scan (all projects)

--- a/docs/infosec-readiness.md
+++ b/docs/infosec-readiness.md
@@ -1556,7 +1556,7 @@ azure-core >= 1.38.0 # Azure SDK core
 
 **Dependency Security:**
 - All dependencies are from well-known, actively maintained projects (AWS, Microsoft, Google, Pallets)
-- AWS, Azure, and GCP dependencies are included by default (`pip install cleancloud`)
+- Cloud SDK dependencies are optional extras — install only what you need (`pip install 'cleancloud[aws]'`, `'cleancloud[azure]'`, `'cleancloud[gcp]'`, or `'cleancloud[all]'`)
 - Minimum version pinning (allows security updates)
 - No transitive dependencies from untrusted sources
 - Dependencies scanned with `pip-audit` in CI
@@ -1593,8 +1593,8 @@ All releases are tagged in GitHub:
 Generate an SBOM for compliance:
 
 ```bash
-pip install cleancloud
-pip freeze | grep -iE "(cleancloud|boto3|azure|click|pyyaml)" > cleancloud-sbom.txt
+pip install 'cleancloud[all]'
+pip freeze | grep -iE "(cleancloud|boto3|azure|click|pyyaml|google)" > cleancloud-sbom.txt
 ```
 
 **Example SBOM:**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cleancloud"
-version = "1.14.1"
+version = "1.15.0"
 description = "Read-only cloud hygiene for AWS, Azure, and GCP. Multi-account org scanning, CI/CD enforcement, and deterministic cost modeling. No agents, no telemetry."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,9 +35,14 @@ classifiers = [
 dependencies = [
     "click>=8.1.0",
     "PyYAML>=6.0",
-    # AWS
+]
+
+[project.optional-dependencies]
+
+aws = [
     "boto3>=1.34.0",
-    # Azure
+]
+azure = [
     "azure-identity>=1.19.0",
     "azure-mgmt-resource>=23.0.0",
     "azure-mgmt-subscription>=3.0.0",
@@ -50,15 +55,19 @@ dependencies = [
     "azure-mgmt-containerregistry>=10.0.0",
     "azure-mgmt-machinelearningservices>=1.0.0",
     "azure-core>=1.38.0",
-    # GCP
+]
+gcp = [
     "google-auth>=2.20.0",
     "google-cloud-compute>=1.19.0",
     "google-cloud-monitoring>=2.19.0",
     "google-cloud-resource-manager>=1.12.0",
     "requests>=2.28.0",
 ]
-
-[project.optional-dependencies]
+all = [
+    "cleancloud[aws]",
+    "cleancloud[azure]",
+    "cleancloud[gcp]",
+]
 
 dev = [
     "pytest>=8.0.0",


### PR DESCRIPTION
Discord user's feedback:

   - Azure file naming — ebs_snapshots_old.py under the Azure rules uses AWS terminology ("EBS"). The code inside is correct Azure logic, but the filename is misleading.

   - Wrong provider in error message — The EnvironmentError handler in scan/command.py defaults to suggesting cleancloud doctor --provider azure even when the user is scanning AWS. It only checks for GCP, everything else falls through to Azure.

   - Heavy install footprint — All three cloud SDKs (AWS, Azure, GCP) are hard dependencies. An Azure-only user has to install boto3 and all the google-cloud packages they'll never use.

   - No per-call API timeouts — Individual provider API calls like snapshots.list() or describe_endpoint don't have explicit timeouts. If a provider API hangs, the scan can freeze indefinitely even though there's a global --timeout flag.

The first two issues are already fixed, This PR fixes just the 3rd issue